### PR TITLE
ART: force GCC 4.8 for build

### DIFF
--- a/build/Android.executable.mk
+++ b/build/Android.executable.mk
@@ -93,6 +93,9 @@ define build-art-executable
   endif
   LOCAL_MULTILIB := $$(art_multilib)
 
+  LOCAL_CC	:= $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-gcc$$(HOST_EXECUTABLE_SUFFIX)
+  LOCAL_CXX	:= $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++$$(HOST_EXECUTABLE_SUFFIX)
+
   include external/libcxx/libcxx.mk
   ifeq ($$(art_target_or_host),target)
     include $(BUILD_EXECUTABLE)

--- a/dex2oat/Android.mk
+++ b/dex2oat/Android.mk
@@ -29,6 +29,9 @@ else
   dex2oat_arch := 32
 endif
 
+LOCAL_CC	:= $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-gcc$$(HOST_EXECUTABLE_SUFFIX)
+LOCAL_CXX	:= $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++$$(HOST_EXECUTABLE_SUFFIX)
+
 ifeq ($(ART_BUILD_TARGET_NDEBUG),true)
   $(eval $(call build-art-executable,dex2oat,$(DEX2OAT_SRC_FILES),libcutils libart-compiler,art/compiler,target,ndebug,$(dex2oat_arch)))
 endif

--- a/runtime/Android.mk
+++ b/runtime/Android.mk
@@ -398,14 +398,20 @@ $$(ENUM_OPERATOR_OUT_GEN): $$(GENERATED_SRC_DIR)/%_operator_out.cc : $(LOCAL_PAT
     # TODO: Loop with ifeq, ART_TARGET_CLANG
     ifneq ($$(ART_TARGET_CLANG_$$(TARGET_ARCH)),true)
       LOCAL_SRC_FILES_$$(TARGET_ARCH) += $$(LIBART_GCC_ONLY_SRC_FILES)
+      LOCAL_CC	:= $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-gcc$$(HOST_EXECUTABLE_SUFFIX)
+      LOCAL_CXX	:= $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++$$(HOST_EXECUTABLE_SUFFIX)
     endif
     ifneq ($$(ART_TARGET_CLANG_$$(TARGET_2ND_ARCH)),true)
       LOCAL_SRC_FILES_$$(TARGET_2ND_ARCH) += $$(LIBART_GCC_ONLY_SRC_FILES)
+      LOCAL_CC	:= $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-gcc$$(HOST_EXECUTABLE_SUFFIX)
+      LOCAL_CXX	:= $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++$$(HOST_EXECUTABLE_SUFFIX)
     endif
   else # host
     LOCAL_CLANG := $$(ART_HOST_CLANG)
     ifeq ($$(ART_HOST_CLANG),false)
       LOCAL_SRC_FILES += $$(LIBART_GCC_ONLY_SRC_FILES)
+      LOCAL_CC := $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-gcc$$(HOST_EXECUTABLE_SUFFIX)
+      LOCAL_CXX := $$(TARGET_TOOLCHAIN_ROOT)/../arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++$$(HOST_EXECUTABLE_SUFFIX)
     endif
     LOCAL_CFLAGS += $$(ART_HOST_CFLAGS)
     ifeq ($$(art_ndebug_or_debug),debug)


### PR DESCRIPTION
GCC 4.9 causes ridiculous segfaults on at least ARM targets for ART.

Change-Id: I51cd3398e69770c00431f5564e19e563c941d6b3

Google apparently has a fix :
https://android.googlesource.com/platform/art/+/376b2bbf7c39108223a7a01568a7b4b04d84eeac

But for some reason, not solves the issue; at least on Android 5.0 Lollipop.

So force GCC 4.8 for now.

Signed-off-by: arter97 qkrwngud825@gmail.com
